### PR TITLE
Improve performance by batching inserts

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2f78222c035f92109de333096f6424ed6cc255df3a43f1529b1219d0a05e8b8b"
+            "sha256": "ac9c4de020d6607c80f4f1089f6ab3bcd11447b1ef825174cbd2d89fbd977a97"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3"
         },
         "sources": [
             {
@@ -18,31 +18,42 @@
     "default": {
         "osmium": {
             "hashes": [
-                "sha256:0178bc3dd46fd304b0a22a951df1a116d37bb0d4869bbe6c566ce1abf39be7e5",
-                "sha256:07f6315af25fb496125d140151e317de0486ddc20254616d2347cd5537091e07",
-                "sha256:090fbcf394b76c7a4e967f55977a1491efaf3276b4a27ec1262cfd13073eb497",
-                "sha256:0b798022ddb598ffa8c5baf979cc0fe275a9419dfdf3ca21a92ede596f99bae2",
-                "sha256:2170516d9c3c95432ea725ac4a0dca590fb263f80b6fc3f361a3d30eb9c41f28",
-                "sha256:35d9ea62e0016466eece390792644192d45dbf12c70637d293b8be408c2390cd",
-                "sha256:455dcd129819b1c47cfcb7c676e362c07b32dc5558bf16eddd0333f8899e331e",
-                "sha256:5545722ce2ead2c1e634ef23e26b694fe06f5768006195762f14ab6496fb72ed",
-                "sha256:68d8a9bab38657362d55ec0c2878acc40a74f4602e263c1c3b75bdfe8135c59c",
-                "sha256:69fd3f0da9ecb3a041075bd84702ef9237c67c09f1a0b6defb00bbb727249259",
-                "sha256:712910c5472726bb62a6e043179697e0a52ebb09b7e4e23dbf4a8d0e31c90e11",
-                "sha256:82d84dbfe437546aad4e427d9b667eb4575b35100e8ff60fd1f0752522126211",
-                "sha256:8475e8dc2186d0817b0254e35f502582592b8b44cd0a9478cbecd6602791ff50",
-                "sha256:851491cddb07e7cf25b74a29e7ceca9c0eac74c45d0a033e6085820e830e1f32",
-                "sha256:8ae2ce116bec61b2e51b181f61214fba06ec25ccd4d51cb42386b8b4b73ccd91",
-                "sha256:8ea713709267a461eaf2c6544f4fe358312558e7448480f5fd0c3fef023e996d",
-                "sha256:b7f774794fac9df16ad745035aa61e28a00c5a75bed3483fa77f67e34dc61920",
-                "sha256:bb40e3e468b47e01f759a1c5de9e5429224ca6b8fe09f690c169480afc7ea840",
-                "sha256:bc67305d09f391d735883efea870c37a3aa2dabf32530026a409eb506b52a2f0",
-                "sha256:bef1b37772b39a438c5b2e65dbc1f3417ef2a8ade829ef1f6f0179431c5bcb7c",
-                "sha256:df9bded041a099a72bc3bfb3732df93c36f96801c2706721d1d8623419e64321",
-                "sha256:e0d4a1049a5bf8445c6e8c6cbc8f247795322870a32ca63f5fdec24cbcc973c2"
+                "sha256:01fb8c2f739148c551914a18bbea4427da5491afe251967f270546dbfd611bbc",
+                "sha256:02b43bfeed6eaeb0331cbcef3712eb1f279ca8f0a2aeddff525a6d1c857e2aa5",
+                "sha256:05b1b90e8d74f88792727583564fc1574c14da58320254b6313e4c398be58fe2",
+                "sha256:1bd137574149f60d10087d1897db0674007f19c1ff7a915b5a3338c99e7400bd",
+                "sha256:24b741dbde41e0b98b3f172bacbceb0081636d523b1669217e99af548f139be0",
+                "sha256:281553c9dce2a7cb5d6cfaa992345e0628554096e46f1f11424521c34a841a60",
+                "sha256:29e83f993829cb9bfcaf3557fdd21fb094e6a08c1bfb8cc45428115f8d76aa9c",
+                "sha256:2d3c06d88f6833bc844c7877fb0909641e3a856c0578ec4c837d4802f2daca19",
+                "sha256:35bbac6f8aabc157ea1111d108b9070f29018bf7da16aca65cde983693ce0434",
+                "sha256:46db96f6ac392d0d7422901cefa7e19c8a0dae53517d0aba5e4f836ac2c3b7a7",
+                "sha256:4b39b150d753aa8acd7bd6061f8a311af1f602a6bb1e47710429002caaac4bc4",
+                "sha256:4ba59cf09cedc1c9728adc7a81e59959d013ef9372a8e718715a56324b6ab69e",
+                "sha256:56e3dafd1dba56a74b21fd79b603ddbea34e120330b90613344d2de50d4dbdea",
+                "sha256:5bab86443dd05f7c220bf9a60d19c03a58374ac3b2dc5d06d461f42dc67fad02",
+                "sha256:61a7851a4d6d7b587feb9db13773d57afd86a7382f7548e69355b92915ae69d3",
+                "sha256:670d14d640933b43532445b4aaa8a82187b2dd522c663057100b9d22ba83fd0a",
+                "sha256:6d2de77a7fd02eac1914f8afe01a202954a64f6f748d1d4381881f92be654c5f",
+                "sha256:753dfc6debd778bf05cbdd504839025c5d4009c56758701d3dc7620db93be9b0",
+                "sha256:8058b44e670505127610f60f982e5641268290117ed1795d8d0f7773d0402630",
+                "sha256:8317f759c252986221e552ca7b61c4eb78154ca46211cb9f3c16de8f3aa9424a",
+                "sha256:86751b942645c13d20d2c95fa75892bd1373d837140f141f87c48461bf592cf9",
+                "sha256:8d2265de887a1e74b2b0535b4e87390fcd0dfa85c1461f3654a55b77530fec26",
+                "sha256:90151f34fe0db80c9d8f8af5ea5bb81b3c1ac048b76df2c26b8c5625205ea0d7",
+                "sha256:9462218cf2001a39b15573e8a8ed11479543e467bf874fe4b0225184417d3ddc",
+                "sha256:a618c441227edbab75e9dd49ff06dbaa4c6d0a72f2e2c388e8e729cbf0097b9a",
+                "sha256:b2f9a117db47447b29049cd79decf38e501a74c966573c62b67a2e43927a46e9",
+                "sha256:ba2f768cc951b6563e88345cf096c7e977e37596f0c9361cfebd2df7cc57ebf9",
+                "sha256:c0aa751a4a852f5066009500ee2226edfebc5110bebb5df1721b0394aee7193b",
+                "sha256:c2206fdc30b85f37951d6893379ee8894d36388eee94fbf356f348d647202166",
+                "sha256:d239f7346d972a6681a126414b764a6900261540f9ef743de97ddce339581b32",
+                "sha256:deeecc2ce5377760d6bdf72f4e0045b1b27192211250ceb5a70ce8aec2fc821a",
+                "sha256:e5764e36cb846af908c6bd827bcec5c8fdc48f9ca9dd718c1a5d0e05ed14c79e",
+                "sha256:f94eef05620a3a4a8a7ce87a0b5c888ca627c16ef0b7b3e0aa5b62e9b3e1c7b2"
             ],
             "index": "pypi",
-            "version": "==2.15.3"
+            "version": "==2.15.4"
         },
         "spatialite": {
             "hashes": [
@@ -54,11 +65,11 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:abc25d0ce2397d070ef07d8c7e706aede7920da163c64997585d42d3537ece3d",
-                "sha256:dd3fcca8488bb1d416aa7469d2f277902f26260c45aa86b667b074cd44b3b115"
+                "sha256:0d8b5afb66e23d80433102e9bd8b5c8b65d34c2a2255b2de58d97bd2ea8170fd",
+                "sha256:f35fb121bafa030bd94e74fcfd44f3c2830039a2ddef7fc87ef1c2d205237b24"
             ],
             "index": "pypi",
-            "version": "==4.36.1"
+            "version": "==4.43.0"
         }
     },
     "develop": {}

--- a/poiconverter/database.py
+++ b/poiconverter/database.py
@@ -56,7 +56,6 @@ class Database:
     def insert_pois(self, pois_with_ids):
         def iterator(pois_with_ids):
             for (id, poi) in pois_with_ids:
-                sql = "INSERT INTO 'Points'(ROWID, id, type, name, geom) VALUES(?,'P',?, GEOMFROMTEXT(?, 4326));"
                 yield [id, poi.node_id, poi.name, "POINT({} {})".format(poi.lon, poi.lat)]
 
         sql = "INSERT INTO 'Points'(ROWID, id, type, name, geom) VALUES(?, ?,'P',?, GEOMFROMTEXT(?, 4326));"
@@ -75,7 +74,7 @@ class Database:
         """
         self.cursor.executemany(sql, iterator(pois_with_ids))
 
-    def insert_tagss(self, pois_with_ids):
+    def insert_tags(self, pois_with_ids):
         def value_iterator(pois_with_ids):
             for (_, poi) in pois_with_ids:
                 for (k, v) in poi.tags.items():
@@ -106,7 +105,7 @@ class Database:
 
         self.insert_pois(pois_with_ids)
         self.insert_root_sub_folders(pois_with_ids)
-        self.insert_tagss(pois_with_ids)
+        self.insert_tags(pois_with_ids)
         self.batched_pois.clear()
 
 

--- a/poiconverter/database.py
+++ b/poiconverter/database.py
@@ -14,6 +14,11 @@ class Database:
     def open_append(self):
         self.db = spatialite.connect(self.file_name)
         self.cursor = self.db.cursor()
+        last_ROWID = self.cursor.execute("SELECT max(ROWID) from Points").fetchone()[0]
+        if last_ROWID is None:
+            self.first_free_points_id = 0
+        else:
+            self.first_free_points_id = last_ROWID + 1
 
     def open_create(self):
         if os.path.isfile(self.file_name):

--- a/poiconverter/database.py
+++ b/poiconverter/database.py
@@ -8,6 +8,8 @@ class Database:
     def __init__(self, init_file):
         self.entries = 0
         self.init_file = init_file
+        self.batch_size = 10000
+        self.batched_pois = []
 
     def open_append(self):
         self.db = spatialite.connect(self.file_name)
@@ -19,6 +21,7 @@ class Database:
         self.db = spatialite.connect(self.file_name)
         self.cursor = self.db.cursor()
         self.initialize_database()
+        self.first_free_points_id = 0
 
     def open(self, file, mode):
         self.file_name = file
@@ -31,6 +34,7 @@ class Database:
             raise ValueError('Wrong mode parameter')
 
     def close(self):
+        self.write_pois()
         self.db.commit()
         self.db.close()
 
@@ -44,33 +48,62 @@ class Database:
                 if command.strip(): #skip empty lines
                     result = self.db.execute(command)
 
-    def insert_poi(self, poi):
-        sql = "INSERT INTO 'Points' VALUES(?,'P',?, GEOMFROMTEXT('POINT({} {})', 4326));".format(poi.lon, poi.lat)
-        params = [poi.node_id, poi.name]
-        result = self.cursor.execute(sql, params)
-        self.row_id = self.cursor.lastrowid # rowid id is used for all other tables in database
+    def insert_pois(self, pois_with_ids):
+        def iterator(pois_with_ids):
+            for (id, poi) in pois_with_ids:
+                sql = "INSERT INTO 'Points'(ROWID, id, type, name, geom) VALUES(?,'P',?, GEOMFROMTEXT(?, 4326));"
+                yield [id, poi.node_id, poi.name, "POINT({} {})".format(poi.lon, poi.lat)]
 
-    def insert_root_sub_folder(self, poi_type):
-        sql = ("SELECT FoldersRoot.id, FoldersSub.id  FROM FoldersSub,FoldersRoot WHERE FoldersSub.name = ?" 
-            "AND FoldersRoot.name = (SELECT RootSubMapping.rootname FROM RootSubMapping"
-            " WHERE RootSubMapping.subname = ?);")
-        root_sub = self.db.execute(sql, (poi_type[1],poi_type[1])).fetchone()
+        sql = "INSERT INTO 'Points'(ROWID, id, type, name, geom) VALUES(?, ?,'P',?, GEOMFROMTEXT(?, 4326));"
+        self.cursor.executemany(sql, iterator(pois_with_ids))
 
-        sql = "INSERT INTO Points_Root_Sub VALUES({},{},{});".format(self.row_id,root_sub[0],root_sub[1])
-        result = self.db.execute(sql)
+    def insert_root_sub_folders(self, pois_with_ids):
+        def iterator(pois_with_ids):
+            for (id, poi) in pois_with_ids:
+                yield [id, poi.type[1], poi.type[1]]
 
-    def insert_tags(self, tags):
-        for key in tags:
-            value = tags[key]
-            result = self.cursor.execute("INSERT OR IGNORE INTO TagValues (name) VALUES(?);", (value,))
-            sql = "INSERT INTO Points_Key_Value (Points_id, TagKeys_id, TagValues_id) VALUES(?, (SELECT id FROM TagKeys WHERE TagKeys.name = ?), (SELECT id FROM TagValues WHERE TagValues.name = ?));"
-            result = self.cursor.execute(sql, (self.row_id, key, value))
+        sql = """INSERT INTO Points_root_sub VALUES(
+            ?,
+            (SELECT fr.id FROM FoldersRoot fr JOIN RootSubMapping rsm ON fr.name = rsm.rootname WHERE rsm.subname = ?),
+            (SELECT fs.id FROM FoldersSub fs WHERE fs.name = ?)
+        )
+        """
+        self.cursor.executemany(sql, iterator(pois_with_ids))
+
+    def insert_tagss(self, pois_with_ids):
+        def value_iterator(pois_with_ids):
+            for (_, poi) in pois_with_ids:
+                for (k, v) in poi.tags.items():
+                    yield [v]
+
+        def pkv_iterator(pois_with_ids):
+            for (id, poi) in pois_with_ids:
+                for (k,v) in poi.tags.items():
+                    yield [id, k, v]
+
+        sql = "INSERT OR IGNORE INTO TagValues (name) VALUES(?);"
+        self.cursor.executemany(sql, value_iterator(pois_with_ids))
+
+        sql = "INSERT INTO Points_Key_Value (Points_id, TagKeys_id, TagValues_id) VALUES(?, (SELECT id FROM TagKeys WHERE TagKeys.name = ?), (SELECT id FROM TagValues WHERE TagValues.name = ?));"
+        self.cursor.executemany(sql, pkv_iterator(pois_with_ids))
 
     def write_poi(self, poi):
-        self.insert_poi(poi)
-        self.insert_root_sub_folder(poi.type)
-        self.insert_tags(poi.tags)
+        self.batched_pois.append(poi)
         self.entries += 1
+        if len(self.batched_pois) >= self.batch_size:
+            self.write_pois()
+
+    def write_pois(self):
+        pois_with_ids = []
+        for poi in self.batched_pois:
+            pois_with_ids.append((self.first_free_points_id, poi))
+            self.first_free_points_id += 1
+
+        self.insert_pois(pois_with_ids)
+        self.insert_root_sub_folders(pois_with_ids)
+        self.insert_tagss(pois_with_ids)
+        self.batched_pois.clear()
+
 
     def read_tags(self):
         sql = "SELECT name, id from TagKeys;"

--- a/poiconverter/poiimporter.py
+++ b/poiconverter/poiimporter.py
@@ -14,16 +14,15 @@ import sqlite3
 from poiconverter.poi import Poi
 from tqdm import tqdm
 
+
 class PoiImporter():
 
     def __init__(self, callback, tag_filter):
         self.callback = callback
         self.tag_filter = tag_filter
-        self.node_id = 0
 
-    def handle_result(self, result): #result is tuple of all database columns
-        self.node_id += 1
-        lat = (result[0] + result[1]) / 2 # use arithmetic mean to calculate location
+    def handle_result(self, result):  # result is tuple of all database columns
+        lat = (result[0] + result[1]) / 2  # use arithmetic mean to calculate location
         lon = (result[2] + result[3]) / 2
         tags = dict()
         for line in result[4].replace("\r\n", " ").split('\r'):
@@ -35,7 +34,8 @@ class PoiImporter():
         node_type = self.tag_filter.tag_matched(tags)
         if node_type:
             name = tags.get('name', '')
-            poi = Poi(self.node_id, name, lat, lon)
+            # mapsforge Poi files do not contain the OSM node id, so always use 0.
+            poi = Poi(0, name, lat, lon)
             poi.set_type(node_type)
             poi.add_tags(tags)
             self.callback(poi)

--- a/poiconverter/poiimporter.py
+++ b/poiconverter/poiimporter.py
@@ -21,16 +21,7 @@ class PoiImporter():
         self.tag_filter = tag_filter
         self.node_id = 0
 
-    def handle_node(self, node):
-        node_type = self.tag_filter.tag_matched(node.tags)
-        if node_type:
-            name = node.tags.get('name', '')
-            poi = Poi(node.id, name, node.location.lat, node.location.lon)
-            for tag in node.tags:
-                poi.add_tag(*tag)
-            self.callback(poi)
-
-    def handle_result(self, result): #result is tuple of all database columns 
+    def handle_result(self, result): #result is tuple of all database columns
         self.node_id += 1
         lat = (result[0] + result[1]) / 2 # use arithmetic mean to calculate location
         lon = (result[2] + result[3]) / 2


### PR DESCRIPTION
By batching inserts, performance can be greatly improved.

On my machine, runtime for importing Spain_Portugal.db went from 3m00 to 1m00.
I verified that the resulting db contains the same elements by comparing the results
of the query
```sql
select p.id, p.type, p.name, FR.name, FS.name, TK.name, TV.name
from Points p
         join Points_Root_Sub PRS on p.ROWID = PRS.Points_id
         join Points_Key_Value PKV on p.ROWID = PKV.Points_id
         join FoldersRoot FR on PRS.FoldersRoot_id = FR.id
         join FoldersSub FS on PRS.FoldersSub_id = FS.id
         join TagKeys TK on PKV.TagKeys_id = TK.id
         join TagValues TV on PKV.TagValues_id = TV.id
order by p.id
;
```
on the db before and after the change.

